### PR TITLE
Improve the `soundmixers.txt` config

### DIFF
--- a/sv_pure_bypass_2-electric_boogaloo/soundmixers.txt
+++ b/sv_pure_bypass_2-electric_boogaloo/soundmixers.txt
@@ -108,23 +108,23 @@
 		"gamestartup" 		"0.25" "1.0" "1.0"   
 
 		"Explosions"            	"1.0" "1.0" "1.0"    
-		"ExplosionsDistant"    "1.6" "1.0" "1.0"
-		"ExplosionsDecoy"    	"1.6" "1.0" "1.0"  	
+		"ExplosionsDistant"    "2.0" "1.0" "1.0"
+		"ExplosionsDecoy"    	"0.0" "1.0" "1.0"  	
 		"BulletImpacts"          "0.2" "1.0" "1.0"
 		"BulletRicochets"       	"0.4" "1.0" "1.0"
 		"Physics"       		"0.8" "1.0" "1.0"
 
-		"DistWeapons"            "1.5" "1.0" "0.3"
-		"Weapons1"           	"0.2" "1.0" "1.0"
-		"FoleyWeapons"         "0.7" "1.0" "1.0"
-		"C4Foley"           	"1.0" "1.0" "1.0"
+		"DistWeapons"            "1.7" "1.0" "0.3"
+		"Weapons1"           	"0.7" "1.0" "1.0"
+		"FoleyWeapons"         "1.4" "1.0" "1.0"
+		"C4Foley"           	"3.5" "1.0" "1.0"
 		"AllWeapons"             "1.0" "1.0" "1.0"
 	    
-		"Ambient"                	"0.25" "1.0" "1.0"
+		"Ambient"                	"0.0" "1.0" "1.0"
 		"Survival"			"1.0" "1.0" "0.3"
 
-		"PlayerFootsteps"        "0" "1.0" "1.0"
-		"GlobalFootsteps"        "2.0" "0.9" "0.9"
+		"PlayerFootsteps"        "0.13" "1.0" "1.0"
+		"GlobalFootsteps"        "1.5" "0.9" "0.9"
 
 		"SelectedMusic"         "0.6" "1.0" "1.0"
 		"BuyMusic"                "0.8" "1.0" "0.0"
@@ -138,7 +138,7 @@
 
 		"Replay"			"1.0" "1.0" "1.0"
 
-		"UI"                    	"1.0" "1.0" "0.2"
+		"UI"                    	"0.2" "1.0" "0.2"
 		
 		"All"                    	"1.0" "1.0" "1.0"
 	}


### PR DESCRIPTION
* `ExplosionsDistant` increased from `1.6` to `2.0` (hear grenades at a longer distance)
* `ExplosionsDecoy` from `1.6` set to `0.0` (disable decoy grenades sound **at a shorter distance\***)
* `DistWeapons` increased from `1.5` to `1.7` (hear gunfire at a longer distance)
* `Weapons1` from `0.2` restored back to `0.7` (hear gunfire at a shorter distance; the default value)
* `FoleyWeapons` increased from `0.7` to `1.4` (louder reload sounds)
* `C4Foley` increased from `1.0` to `3.5` (louder the C4 beep sound)
* `Ambient` from `0.25` set to `0.0` (no ambient sound)
* `PlayerFootsteps` from `0.0` restored back to `0.13` (it's weird to not hear your own footsteps; it's the default value, still very quiet)
* `GlobalFootsteps` from `2.0` reduced to `1.5` (`2.0` was a bit too loud compared to other sounds)
* `UI` from `1.0` restored back to `0.2`

\* You can still hear decoys at a longer distance. Period.

#### My own thoughts

This is very overpowered. Almost on every map on T spawn you can hear gunfire happening at CT spawn (it's quiet, but loud enough to locate where it's coming from). If you move to mid, the gunfire is resonant and no doubt you will be able to locate it. Increased the C4 beep volume - ever been a CT and having doubts where the bomb was planted? Well, fear no more. No ambient sound and no decoy sound changes everything.