### PR TITLE
Added an another showcase of the model_bug

### DIFF
--- a/model_bug/README.md
+++ b/model_bug/README.md
@@ -12,6 +12,8 @@ I will be using the official map de_cache as an example in this issue.
 
 https://streamable.com/gob4m
 
+Same issue being used in Team Fortress 2 : https://www.youtube.com/watch?v=J6-YtN9352E
+
 ### Your system information
 
 OS agnostic
@@ -43,6 +45,8 @@ The chosen prop should now be unloaded with the following error in console: Erro
 ### Video example:
 
 https://streamable.com/gob4m
+
+https://www.youtube.com/watch?v=J6-YtN9352E
 
 ### Disclosure
 


### PR DESCRIPTION
I'm not the author of this video, nor the one who made the showcased map/server. This use the same reported issue to unload the 2fort balcony buildings in a more obvious and advantaging way than the showcased cs:go streamable included video.