### PR TITLE
Fixed net_dumpeventstats

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ Why post stuff like this in public? Valve doesn't care anymore, see the [model_b
 | sv_pure_bypass_3   | Yes      | 24-07-2020 | [06-08-2020](https://blog.counter-strike.net/index.php/2020/08/31269/) | [DepoSit](https://www.youtube.com/watch?v=aL2rQzhFTn4), [@mbhound](https://github.com/mbhound) and [@szmarczak](https://github.com/szmarczak) |
 | sv_pure_bypass_4   | Yes      | 06-08-2020 | [17-08-2020](https://blog.counter-strike.net/index.php/2020/08/31374/) | [@szmarczak](https://github.com/szmarczak) and [@mbhound](https://github.com/mbhound) |
 | sv_pure_bypass_5   | No       | 06-08-2020 |             | [@szmarczak](https://github.com/szmarczak) |
-| con_logfile_tricks | Somewhat | ??-??-2018 |             | [@kkthxbye-code](https://github.com/kkthxbye-code) |
-| netcon_stuff       | No       | ??-03-2020 |             | [@403-fruit](https://github.com/403-Fruit) and [@szmarczak](https://github.com/szmarczak) |
+| con_logfile_tricks | Somewhat | ??-??-2018 | [26-08-2020](https://blog.counter-strike.net/index.php/2020/08/31476/) | [@kkthxbye-code](https://github.com/kkthxbye-code) |
+| netcon_stuff       | No       | ??-03-2020 | [26-08-2020](https://blog.counter-strike.net/index.php/2020/08/31476/) | [@403-fruit](https://github.com/403-Fruit) and [@szmarczak](https://github.com/szmarczak) |


### PR DESCRIPTION
*– Fixed net_dumpeventstats command to be cheat-protected.*

It requires sv_cheats 1 now.