### PR TITLE
Fixed net_dumpeventstats

### DIFF
--- a/con_logfile_tricks/README.md
+++ b/con_logfile_tricks/README.md
@@ -2,5 +2,4 @@ While a bunch of these got fixed after my reports, there are still a few possibl
 
 In short you make an autohotkey that spams a button while ingame, binds the button to something like ~~net_dumpeventstats~~. Then with a con_logfile set, continually parse the logfile waiting for events. ~~The net_dumpeventstats allows to make an accurate external bomb timer for example~~. The most useful commands were fixed though, but there's probably more if you look properly.
 
-Example usages of net_dumpeventstats(which is [fixed](https://blog.counter-strike.net/index.php/2020/08/31476/)) including an accurate external bomb timer on [netcon_stuff](netcon_stuff)
-
+Example usages of net_dumpeventstats (which are [fixed](https://blog.counter-strike.net/index.php/2020/08/31476/) now) include an accurate external bomb timer on [netcon_stuff](../netcon_stuff/0s_defuser).

--- a/con_logfile_tricks/README.md
+++ b/con_logfile_tricks/README.md
@@ -2,5 +2,5 @@ While a bunch of these got fixed after my reports, there are still a few possibl
 
 In short you make an autohotkey that spams a button while ingame, binds the button to something like ~~net_dumpeventstats~~. Then with a con_logfile set, continually parse the logfile waiting for events. ~~The net_dumpeventstats allows to make an accurate external bomb timer for example~~. The most useful commands were fixed though, but there's probably more if you look properly.
 
-Example usages of net_dumpeventstats(which is [now](https://blog.counter-strike.net/index.php/2020/08/31476/) fixed) including an accurate external bomb timer on [netcon_stuff](netcon_stuff)
+Example usages of net_dumpeventstats(which is [fixed](https://blog.counter-strike.net/index.php/2020/08/31476/)) including an accurate external bomb timer on [netcon_stuff](netcon_stuff)
 

--- a/con_logfile_tricks/README.md
+++ b/con_logfile_tricks/README.md
@@ -1,3 +1,6 @@
 While a bunch of these got fixed after my reports, there are still a few possible advantages to be gained, by parsing a console logfile while playing.
 
-In short you make an autohotkey that spams a button while ingame, binds the button to something like net_dumpeventstats. Then with a con_logfile set, continually parse the logfile waiting for events. The net_dumpeventstats allows to make an accurate external bomb timer for example. The most useful commands were fixed though, but there's probably more if you look properly.
+In short you make an autohotkey that spams a button while ingame, binds the button to something like ~~net_dumpeventstats~~. Then with a con_logfile set, continually parse the logfile waiting for events. ~~The net_dumpeventstats allows to make an accurate external bomb timer for example~~. The most useful commands were fixed though, but there's probably more if you look properly.
+
+Example usages of net_dumpeventstats(which is [now](https://blog.counter-strike.net/index.php/2020/08/31476/) fixed) including an accurate external bomb timer on [netcon_stuff](netcon_stuff)
+


### PR DESCRIPTION
[*– Fixed net_dumpeventstats command to be cheat-protected.*](https://blog.counter-strike.net/index.php/2020/08/31476/)

It requires sv_cheats 1 now.